### PR TITLE
Replace /bin/bash with /bin/sh and quote some variables

### DIFF
--- a/build/create_tar.sh
+++ b/build/create_tar.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Create release tarball
 #

--- a/build/init_autotools.sh
+++ b/build/init_autotools.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # This must be called from within the top source dir.
 #

--- a/build/version-gen.sh
+++ b/build/version-gen.sh
@@ -4,14 +4,14 @@ set -e
 TOPSRCDIR=""
 if test $# -eq 1;
 then
-    TOPSRCDIR=$1/
+    TOPSRCDIR="$1/"
 fi
 
-VERSION=$(${TOPSRCDIR}version.sh $@)
+VERSION=$("${TOPSRCDIR}version.sh" "$@")
 
 OFILE=${PWD}/src/app_version.c
 
-cat <<EOF >${OFILE}
+cat <<EOF >"${OFILE}"
 #include "src/version.h"
 char const app_version[] = "${VERSION}";
 EOF

--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -2,7 +2,7 @@
 if !USE_VERSION_FILE
 .FORCE: src/app_version.c
 src/app_version.c:
-	 bash $(top_srcdir)/build/version-gen.sh ${top_srcdir}
+	 /bin/sh $(top_srcdir)/build/version-gen.sh ${top_srcdir}
 endif
 
 # pipexec itself

--- a/version.sh
+++ b/version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 TOPSRCDIR=""

--- a/version.sh
+++ b/version.sh
@@ -4,8 +4,8 @@ set -e
 TOPSRCDIR=""
 if test $# -eq 1;
 then
-    TOPSRCDIR=$1
-    cd ${TOPSRCDIR}
+    TOPSRCDIR="$1"
+    cd "${TOPSRCDIR}"
 fi
 
 if test -f version.txt;


### PR DESCRIPTION
* Replace /bin/bash with /bin/sh
    1. Not every system provides bash by default.
    2. Many systems don't install bash into /bin (but /usr/bin, /usr/local/bin, …)
    3. Your shell scripts are already POSIX-sh compatible, so it's not needed to require one particular shell implementation.

* Quote variables containing FS paths in shell scripts
    * To make them more robust; paths *may* contain spaces.