### PR TITLE
Fix basic tests.sh for macos

### DIFF
--- a/examples.txt
+++ b/examples.txt
@@ -1,12 +1,20 @@
-./pipexec -l 2 -- [A /bin/ls -l ] [B /bin/grep LIC ] "{A:1>B:0}" "{PARENT:0=A:0}" "{PARENT:1=B:1}" "{PARENT:2=B:2}"
+# Support variable - MacOS doesn't have grep in /bin.
 
-./pipexec -l 2 -- [A /bin/echo Hallo ] [B /bin/echo Bye ] [WC /usr/bin/wc ] "{A:1>WC:0}" "{B:1>WC:0}" "{PARENT:0=A:0}" "{PARENT:1=WC:1}" "{PARENT:2=WC:2}"
+if [ -x /bin/grep ]; then
+    GREPPATH=/bin
+else
+    GREPPATH=/usr/bin
+fi
+
+./pipexec -l 2 -- [ A /bin/ls -l ] [ B $GREPPATH/grep LIC ] "{A:1>B:0}" "{PARENT:0=A:0}" "{PARENT:1=B:1}" "{PARENT:2=B:2}"
+
+./pipexec -l 2 -- [ A /bin/echo Hallo ] [ B /bin/echo Bye ] [ WC /usr/bin/wc ] "{A:1>WC:0}" "{B:1>WC:0}" "{PARENT:0=A:0}" "{PARENT:1=WC:1}" "{PARENT:2=WC:2}"
 
 
-./pipexec -l 2 -- [A cmd1 arg] [B cmd2 arg arg] [C cmd3] "{IN:0=A:0}" "{A:1>B:4}" "{B:4>C:0}" "{C:1>A:0}" "{C:5>B:1}" "{A:7>C:12}" "{C:4=OUT:1}"
+./pipexec -l 2 -- [ A cmd1 arg ] [ B cmd2 arg arg ] [ C cmd3 ] "{IN:0=A:0}" "{A:1>B:4}" "{B:4>C:0}" "{C:1>A:0}" "{C:5>B:1}" "{A:7>C:12}" "{C:4=OUT:1}"
 
 
-./pipexec -l 2 -- [PRINT /usr/bin/printf "Hello\nThis is pipexec test\nAssume this is a long SQL query with a very long output\nAnd you need to do two things with the result.\n" ] [PTEE /home/florath/devel/pe2/BUILD/bin/ptee 5 6 ] [GLOBWC /usr/bin/wc ] [GREP /bin/grep pipe ] [LOCWC /usr/bin/wc ] "{PRINT:1>PTEE:0}" "{PTEE:5>GLOBWC:0}" "{PTEE:6>GREP:0}" "{GREP:1>LOCWC:0}"
+./pipexec -l 2 -- [ PRINT /usr/bin/printf "Hello\nThis is pipexec test\nAssume this is a long SQL query with a very long output\nAnd you need to do two things with the result.\n" ] [ PTEE /home/florath/devel/pe2/BUILD/bin/ptee 5 6 ] [ GLOBWC /usr/bin/wc ] [ GREP $GREPPATH/grep pipe ] [ LOCWC /usr/bin/wc ] "{PRINT:1>PTEE:0}" "{PTEE:5>GLOBWC:0}" "{PTEE:6>GREP:0}" "{GREP:1>LOCWC:0}"
 
-./pipexec -l 2 -- [PTEST /home/florath/devel/pe2/pipexec/ptest ] [TEE /usr/bin/tee /tmp/ptest1.log ] [DD /bin/dd of=/tmp/ptest2.log ] "{PTEST:1>TEE:0}" "{TEE:1>PTEST:0}" "{PTEST:3>DD:0}"
+./pipexec -l 2 -- [ PTEST /home/florath/devel/pe2/pipexec/ptest ] [ TEE /usr/bin/tee /tmp/ptest1.log ] [ DD /bin/dd of=/tmp/ptest2.log ] "{PTEST:1>TEE:0}" "{TEE:1>PTEST:0}" "{PTEST:3>DD:0}"
 

--- a/test/basic_tests.sh
+++ b/test/basic_tests.sh
@@ -18,18 +18,30 @@ if ${PE} 2>/dev/null; then
     fail
 fi
 
+if [ -x /bin/true ]; then
+    TRUEPATH=/bin
+else
+    TRUEPATH=/usr/bin
+fi
+
+if [ -x /bin/grep ]; then
+    GREPPATH=/bin
+else
+    GREPPATH=/usr/bin
+fi
+
 echo "TEST: check return code when all childs succeed"
-if ! ${PE} -- [ A /bin/true ]; then
+if ! ${PE} -- [ A $TRUEPATH/true ]; then
     fail
 fi
 
 echo "TEST: check return code when one child fails"
-if ${PE} -- [ A /bin/true ] [ B /bin/false ] [ C /bin/true ]; then
+if ${PE} -- [ A $TRUEPATH/true ] [ B $TRUEPATH/false ] [ C $TRUEPATH/true ]; then
     fail
 fi
 
 echo "TEST: simple pipe"
-RES=$(./bin/pipexec -- [ ECHO /bin/echo Hello World ] [ CAT /bin/cat ] [ GREP /bin/grep Hello ] '{ECHO:1>CAT:0}' '{CAT:1>GREP:0}')
+RES=$(./bin/pipexec -- [ ECHO /bin/echo Hello World ] [ CAT /bin/cat ] [ GREP $GREPPATH/grep Hello ] '{ECHO:1>CAT:0}' '{CAT:1>GREP:0}')
 if test "${RES}" != "Hello World"; then
     fail
 fi


### PR DESCRIPTION
Turns out the build instructions work "out of the box" on MacOS (with command line build tools installed).

However, true/false/grep aren't in /bin on MacOS, so I had to tweak `basic_tests.sh` and `examples.txt`.

`examples.txt` was also missing spaces around the square brackets.